### PR TITLE
Refactor Board class, add #cell_maker/#grid_maker and tests

### DIFF
--- a/lib/board.rb
+++ b/lib/board.rb
@@ -1,24 +1,49 @@
 class Board
   attr_reader :cells
   def initialize(length = 4, width = 4)
-    @cells = {
-      "A1" => Cell.new("A1"),
-      "A2" => Cell.new("A2"),
-      "A3" => Cell.new("A3"),
-      "A4" => Cell.new("A4"),
-      "B1" => Cell.new("B1"),
-      "B2" => Cell.new("B2"),
-      "B3" => Cell.new("B3"),
-      "B4" => Cell.new("B4"),
-      "C1" => Cell.new("C1"),
-      "C2" => Cell.new("C2"),
-      "C3" => Cell.new("C3"),
-      "C4" => Cell.new("C4"),
-      "D1" => Cell.new("D1"),
-      "D2" => Cell.new("D2"),
-      "D3" => Cell.new("D3"),
-      "D4" => Cell.new("D4")
-    }
+    @cells = cell_maker(length, width)
+    # @cells = {
+    #   "A1" => Cell.new("A1"),
+    #   "A2" => Cell.new("A2"),
+    #   "A3" => Cell.new("A3"),
+    #   "A4" => Cell.new("A4"),
+    #   "B1" => Cell.new("B1"),
+    #   "B2" => Cell.new("B2"),
+    #   "B3" => Cell.new("B3"),
+    #   "B4" => Cell.new("B4"),
+    #   "C1" => Cell.new("C1"),
+    #   "C2" => Cell.new("C2"),
+    #   "C3" => Cell.new("C3"),
+    #   "C4" => Cell.new("C4"),
+    #   "D1" => Cell.new("D1"),
+    #   "D2" => Cell.new("D2"),
+    #   "D3" => Cell.new("D3"),
+    #   "D4" => Cell.new("D4")
+    # }
+  end
+
+  def grid_maker(length, width)
+    width = width - 1
+    l = "A"
+    cells = []
+    length.times do
+      w = "1"
+      coordinate = [l , w].join    
+      cells << coordinate
+      width.times do
+        w = w.next
+        coordinate = [l, w].join
+        cells << coordinate
+      end
+      l = l.next
+      coordinate = [l, w].join
+    end
+    cells
+  end
+
+  def cell_maker(length, width)
+    grid = grid_maker(length, width)
+    grid.reduce({}) { |cells, name| cells[name] = Cell.new(name); cells}
   end
 
   def valid_coordinate?(coordinate)

--- a/spec/board_spec.rb
+++ b/spec/board_spec.rb
@@ -17,6 +17,16 @@ RSpec.describe Board do
         expect(cell).to be_a(Cell)
       end
     end
+
+    it 'can initialize with a custom board size' do
+      big_board = Board.new(27, 27)
+      expect(big_board).to be_a(Board)
+      expect(big_board.cells).to be_a(Hash)
+      expect(big_board.cells.length).to eq(729)
+      big_board.cells.keys.each do |cell_name|
+        expect(cell_name).to be_a(String)
+      end
+    end
   end
 
   describe '#valid_coordinate?' do


### PR DESCRIPTION
Refactor Board class initialization, and add #cell_maker and #grid_maker helper methods. initialize can now pass two arguments in the form of integers that default to a value of 4. It will  use these arguments in conjunction with the grid maker to create an array of coordinate positions and cell maker uses those to create a hash of coordinates and associated cells.